### PR TITLE
Fix build of PHP 7.0 image

### DIFF
--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -19,13 +19,10 @@ RUN yum install -y epel-release http://rpms.remirepo.net/enterprise/remi-release
     INSTALL_PKGS="php php-devel php-ast php-bcmath php-cli php-common php-dba php-gd php-intl php-json php-mbstring \
                   php-mcrypt php-mysqlnd php-opcache php-pdo php-pear php-pecl-igbinary \
                   php-pecl-memcache php-pecl-mongodb php-pecl-redis php-pecl-scrypt php-pecl-uuid php-pecl-xdebug php-pgsql \
-                  libzip ImageMagick ImageMagick-devel" && \
+                  php-pecl-zip php-pecl-imagick" && \
     yum install -y --enablerepo=remi-php70,epel-release --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
-    yum clean all -y && \
-    pecl install zip && \
-    pecl install imagick && \
-    pecl clear-cache
+    yum clean all -y
 
 # Copy the S2I scripts from the specific language image to $STI_SCRIPTS_PATH
 COPY ./s2i/bin/ $STI_SCRIPTS_PATH


### PR DESCRIPTION
Hi @caruccio, how are you doing?

I don't know if you are still maintaining/updating this repo, but I stumbled across it and found out that the building of PHP 7.0 image wasn't working...

Installation of zip via "pecl install" is no longer working, causing the
following error:

configure: error: Please reinstall the libzip distribution
ERROR: `/var/tmp/zip/configure --with-php-config=/usr/bin/php-config'
failed

Fixing the problem by installing it through rpm package.